### PR TITLE
!744 【fix】【openMind】生成的随机code码长度有时不是32位，导致偶现登录失败

### DIFF
--- a/src/main/java/com/om/utils/CodeUtil.java
+++ b/src/main/java/com/om/utils/CodeUtil.java
@@ -62,6 +62,11 @@ public class CodeUtil {
             "UsernameToken Username=\"%s\",PasswordDigest=\"%s\",Nonce=\"%s\",Created=\"%s\"";
 
     /**
+     * 随机字符串生成源.
+     */
+    private static final String DATA_FOR_RANDOM_STRING = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+    /**
      * 发送验证码并返回字符串数组.
      *
      * @param accountType 账户类型
@@ -293,6 +298,15 @@ public class CodeUtil {
     public String randomStrBuilder(int strLength) throws NoSuchAlgorithmException {
         SecureRandom random = SecureRandom.getInstance("DRBG",
                 DrbgParameters.instantiation(256, Capability.RESEED_ONLY, null));
-        return new BigInteger(160, random).toString(strLength);
+        if (strLength < 1) {
+            throw new IllegalArgumentException();
+        }
+        StringBuilder sb = new StringBuilder(strLength);
+        for (int i = 0; i < strLength; i++) {
+            int rndCharAt = random.nextInt(DATA_FOR_RANDOM_STRING.length());
+            char rndChar = DATA_FOR_RANDOM_STRING.charAt(rndCharAt);
+            sb.append(rndChar);
+        }
+        return sb.toString();
     }
 }


### PR DESCRIPTION
[!744 【fix】【openMind】生成的随机code码长度有时不是32位，导致偶现登录失败](https://github.com/opensourceways/om-webserver/commit/2d992548c82c35c1f75ce49e82996ca1c0bd7535)