### PR TITLE
feat: 使用邮箱服务发送验证码时，发件人名称<发件人邮箱> 改为配置项

### DIFF
--- a/src/main/java/com/om/utils/CodeUtil.java
+++ b/src/main/java/com/om/utils/CodeUtil.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -64,6 +65,9 @@ public class CodeUtil {
      * 随机字符串生成源.
      */
     private static final String DATA_FOR_RANDOM_STRING = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+    @Value("${community.email.sender:Open Source Community<%s>}")
+    private String emailSender;
 
     /**
      * 新增的发送短信的服务.
@@ -173,7 +177,7 @@ public class CodeUtil {
         try {
             MimeMessage message = mailSender.createMimeMessage();
             MimeMessageHelper messageHelper = new MimeMessageHelper(message);
-            String format = String.format("Open Source Community<%s>", from); // 发件人名称<发件人邮箱>
+            String format = String.format(emailSender, from); // 发件人名称<发件人邮箱>
             messageHelper.setFrom(format);
             messageHelper.setTo(to);
             messageHelper.setSubject(title);


### PR DESCRIPTION
使用邮箱服务发送验证码时，发件人名称<发件人邮箱> 改为配置项,默认为 Open Source Community<%s>